### PR TITLE
Add extra size to Magpul receivers

### DIFF
--- a/WTT-Armory/Resources/db/CustomItems/WeaponMasada.json
+++ b/WTT-Armory/Resources/db/CustomItems/WeaponMasada.json
@@ -1441,6 +1441,7 @@
         "rcid": ""
       },
 	  "ExtraSizeLeft": 1,
+      "ExtraSizeUp": 1,
 	  "Weight": 0.47,
       "Slots": [
         {
@@ -1682,6 +1683,7 @@
         "rcid": ""
       },
 	  "ExtraSizeLeft": 1,
+      "ExtraSizeUp": 1,
 	  "Weight": 0.476,
       "Slots": [
         {


### PR DESCRIPTION
The Magpul Masada container has a height of 1. This would be fine if it had pistol grips that increase the size of the rifle down one - but the rifle itself only takes 1 slot vertically and relies on a magazine to increase it's vertical size. My mod, which removes extra size penalties from magazines, causes your mod's gun to look weird and results in you receiving "bug reports" regarding the height.

Since the gun's container is *essentially* just a pistol grip, it makes sense to ensure that the receiver creates the extra size vertically left behind from the pistol grip not adding size downward.