### PR TITLE
Fix bots not shooting on Headless client (SPT 4.1)

### DIFF
--- a/WTT-ArmoryClient/Patches/HyperBurstPatches.cs
+++ b/WTT-ArmoryClient/Patches/HyperBurstPatches.cs
@@ -91,7 +91,7 @@ namespace WTTArmoryClient.Patches
         [PatchPrefix]
         private static bool Prefix(Weapon __instance, ref int __result)
         {
-            bool isYourPlayer = __instance?.Owner != null && __instance?.Owner?.ID != null && __instance.Owner.ID == Singleton<GameWorld>.Instance.MainPlayer.ProfileId;
+            bool isYourPlayer = __instance?.Owner?.ID != null && __instance.Owner.ID == Singleton<GameWorld>.Instance?.MainPlayer?.ProfileId;
 
             if (!isYourPlayer || !Plugin.GunHasHyperburst || __instance.SelectedFireMode == Weapon.EFireMode.single)
                 return true;


### PR DESCRIPTION
Since SPT 4.1, it looks like `MainPlayer` has been removed from the Fika Headless world instance. This caused `AutoFireRatePatch` to silently fail when evaluating `isYourPlayer`, as the expression was not null-safe.

As a result, bots were unable to shoot. I reproduced [the issue](https://github.com/project-fika/Fika-Headless/issues/90) on a regular Windows installation using an Armory build from the current `4.1-dev` branch.

This PR makes the property access null-safe and fixes the issue.